### PR TITLE
Fix admin groups page missing file and verify group ownership

### DIFF
--- a/admin/views/groups-page.php
+++ b/admin/views/groups-page.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Groups management page
+ *
+ * @package WooMemberShare
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$group_label_plural   = WMS_Admin::get_label( 'group', true );
+$member_label_plural  = WMS_Admin::get_label( 'subaccount', true );
+?>
+<div class="wrap">
+    <h1><?php echo esc_html( sprintf( __( '%s Management', WOO_MEMBER_SHARE_TEXT_DOMAIN ), $group_label_plural ) ); ?></h1>
+
+    <table class="widefat fixed striped">
+        <thead>
+        <tr>
+            <th><?php esc_html_e( 'ID', WOO_MEMBER_SHARE_TEXT_DOMAIN ); ?></th>
+            <th><?php esc_html_e( 'Group Name', WOO_MEMBER_SHARE_TEXT_DOMAIN ); ?></th>
+            <th><?php esc_html_e( 'Owner', WOO_MEMBER_SHARE_TEXT_DOMAIN ); ?></th>
+            <th><?php echo esc_html( ucfirst( $member_label_plural ) ); ?></th>
+            <th><?php esc_html_e( 'Status', WOO_MEMBER_SHARE_TEXT_DOMAIN ); ?></th>
+            <th><?php esc_html_e( 'Created', WOO_MEMBER_SHARE_TEXT_DOMAIN ); ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php if ( ! empty( $groups ) ) : ?>
+            <?php foreach ( $groups as $group ) : ?>
+                <tr>
+                    <td><?php echo esc_html( $group->id ); ?></td>
+                    <td><?php echo esc_html( $group->group_name ); ?></td>
+                    <td>
+                        <?php
+                        $owner = get_user_by( 'id', $group->customer_user_id );
+                        echo esc_html( $owner ? $owner->display_name : '' );
+                        ?>
+                    </td>
+                    <td>
+                        <?php
+                        $members = WMS_Database::get_group_members( $group->id );
+                        echo esc_html( count( $members ) . '/' . $group->max_subaccounts );
+                        ?>
+                    </td>
+                    <td><?php echo esc_html( ucfirst( $group->status ) ); ?></td>
+                    <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $group->created_date ) ) ); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php else : ?>
+            <tr>
+                <td colspan="6"><?php esc_html_e( 'No groups found.', WOO_MEMBER_SHARE_TEXT_DOMAIN ); ?></td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</div>

--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -62,6 +62,25 @@ class WMS_Database {
         
         return $wpdb->get_results($sql);
     }
+
+    /**
+     * Get group by ID
+     *
+     * @param int $group_id Group ID
+     * @return object|null Group object or null if not found
+     */
+    public static function get_group_by_id($group_id) {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'share_membership_groups';
+
+        $sql = $wpdb->prepare(
+            "SELECT * FROM $table_name WHERE id = %d",
+            $group_id
+        );
+
+        return $wpdb->get_row($sql);
+    }
     
     /**
      * Create a new group

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -200,23 +200,10 @@ class WMS_Frontend {
         $email = sanitize_email($_POST['invite_email']);
         
         // Verify group ownership
-        $group = WMS_Database::get_group_by_customer_variation($user_id, 0);
-        if (!$group || $group->id != $group_id) {
-            // More specific check needed
-            $groups = WMS_Database::get_customer_groups($user_id);
-            $owns_group = false;
-            foreach ($groups as $owned_group) {
-                if ($owned_group->id == $group_id) {
-                    $group = $owned_group;
-                    $owns_group = true;
-                    break;
-                }
-            }
-            
-            if (!$owns_group) {
-                wc_add_notice(__('You do not have permission to manage this group.', WOO_MEMBER_SHARE_TEXT_DOMAIN), 'error');
-                return;
-            }
+        $group = WMS_Database::get_group_by_id($group_id);
+        if (!$group || $group->customer_user_id != $user_id) {
+            wc_add_notice(__('You do not have permission to manage this group.', WOO_MEMBER_SHARE_TEXT_DOMAIN), 'error');
+            return;
         }
         
         // Validate email
@@ -341,16 +328,8 @@ class WMS_Frontend {
         }
         
         // Verify group ownership
-        $groups = WMS_Database::get_customer_groups($user_id);
-        $owns_group = false;
-        foreach ($groups as $group) {
-            if ($group->id == $group_id) {
-                $owns_group = true;
-                break;
-            }
-        }
-        
-        if (!$owns_group) {
+        $group = WMS_Database::get_group_by_id($group_id);
+        if (!$group || $group->customer_user_id != $user_id) {
             wc_add_notice(__('You do not have permission to rename this group.', WOO_MEMBER_SHARE_TEXT_DOMAIN), 'error');
             return;
         }
@@ -374,16 +353,8 @@ class WMS_Frontend {
         $group_id = intval($_POST['group_id']);
         
         // Verify group ownership
-        $groups = WMS_Database::get_customer_groups($user_id);
-        $owns_group = false;
-        foreach ($groups as $group) {
-            if ($group->id == $group_id) {
-                $owns_group = true;
-                break;
-            }
-        }
-        
-        if (!$owns_group) {
+        $group = WMS_Database::get_group_by_id($group_id);
+        if (!$group || $group->customer_user_id != $user_id) {
             wc_add_notice(__('You do not have permission to join this group.', WOO_MEMBER_SHARE_TEXT_DOMAIN), 'error');
             return;
         }


### PR DESCRIPTION
## Summary
- implement `get_group_by_id` in database layer
- tighten group ownership checks for invitations and group actions
- add missing admin `groups-page.php` view

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b4c545bc8331bc44b837504b891b